### PR TITLE
Compatibility with sqlcipher 4.x

### DIFF
--- a/scab.py
+++ b/scab.py
@@ -27,6 +27,10 @@ c2 = db.cursor()
 # param binding doesn't work for pragmas, so use a direct string concat
 for cursor in [c, c2]:
     cursor.execute(f'PRAGMA KEY = "x\'{key}\'"')
+    cursor.execute(f'PRAGMA cipher_page_size = 1024')
+    cursor.execute(f'PRAGMA kdf_iter = 64000')
+    cursor.execute(f'PRAGMA cipher_hmac_algorithm = HMAC_SHA1')
+    cursor.execute(f'PRAGMA cipher_kdf_algorithm = PBKDF2_HMAC_SHA1')
 
 # Hold numeric user id to conversation/user names
 conversations = {}


### PR DESCRIPTION
SQLCipher 4.x changes the cipher defaults; therefore, it is now necessary to pass these PRAGMAs to set the SQLCipher 3.x configuration for this to work.